### PR TITLE
fix(web): 支持配置局域网开发来源

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -7,6 +7,20 @@ npm install
 npm run dev
 ```
 
+如果通过 `npm run dev` 输出的局域网 `Network` 地址访问开发站点，需要允许对应的 hostname，否则 Next.js 可能会阻止开发资源（包括 HMR），导致页面交互失效。例如：
+
+```bash
+NEXT_ALLOWED_DEV_ORIGINS=192.168.31.245 npm run dev
+```
+
+多个 hostname 可以用逗号分隔：
+
+```bash
+NEXT_ALLOWED_DEV_ORIGINS=192.168.31.245,my-dev-host.local npm run dev
+```
+
+修改配置后需要重启开发服务器。
+
 生产构建：
 
 ```bash

--- a/web/next-config-utils.mjs
+++ b/web/next-config-utils.mjs
@@ -1,0 +1,8 @@
+export function parseAllowedDevOrigins(value) {
+  return (
+    value
+      ?.split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean) ?? []
+  );
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
+import { parseAllowedDevOrigins } from "./next-config-utils.mjs";
+
+const allowedDevOrigins = parseAllowedDevOrigins(
+  process.env.NEXT_ALLOWED_DEV_ORIGINS,
+);
 
 const nextConfig: NextConfig = {
   distDir: process.env.NEXT_DIST_DIR ?? ".next",
+  ...(allowedDevOrigins.length > 0 ? { allowedDevOrigins } : {}),
 };
 
 export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "prebuild": "npm run generate:content",
     "build": "next build --webpack",
     "start": "next start",
-    "test": "NEXT_DIST_DIR=.next-test npm run build && node --test tests/rendered-html.test.mjs",
+    "test": "NEXT_DIST_DIR=.next-test npm run build && node --test \"tests/*.test.mjs\"",
     "lint": "eslint . --ignore-pattern dist --ignore-pattern .next --ignore-pattern .next-test"
   },
   "dependencies": {

--- a/web/tests/next-config.test.mjs
+++ b/web/tests/next-config.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAllowedDevOrigins } from "../next-config-utils.mjs";
+
+test("parseAllowedDevOrigins returns no origins when unset", () => {
+  assert.deepEqual(parseAllowedDevOrigins(undefined), []);
+});
+
+test("parseAllowedDevOrigins parses comma-separated hostnames", () => {
+  assert.deepEqual(
+    parseAllowedDevOrigins("192.168.31.245, my-dev-host.local ,,"),
+    ["192.168.31.245", "my-dev-host.local"],
+  );
+});


### PR DESCRIPTION
## 修改内容

- 通过 `NEXT_ALLOWED_DEV_ORIGINS` 配置 Next.js `allowedDevOrigins`
- 支持逗号分隔的多个开发 hostname，并忽略空值
- 在 `web/README.md` 中补充通过局域网 `Network` 地址访问时的配置说明
- 添加配置解析测试，并让现有 `npm test` 覆盖 `tests/*.test.mjs`

## 原因

通过 `next dev` 输出的局域网 `Network` 地址访问教学站时，Next.js 可能会阻止来自该 hostname 的开发资源请求（包括 HMR），导致页面能显示但客户端交互没有正常初始化。

这个实现不硬编码任何局域网 IP，而是让开发者按自己的网络环境显式配置允许的 hostname。

## 验证

- `npm test` ✅ — 4 tests passed, 0 failed
- `npm run lint` ✅ — no lint errors
- 已检查分支相对 `main` 仅包含本 Issue 相关的 5 个文件改动

Fixes #2